### PR TITLE
Revert "Move seek arg to post-encode"

### DIFF
--- a/lib/voice/Piper.js
+++ b/lib/voice/Piper.js
@@ -166,30 +166,43 @@ class Piper extends EventEmitter {
             } else {
                 if(this.libopus) {
                     if(options.opusPassthrough) {
-                        this.streams.push(source = source.pipe(new OggOpusPassthroughTransformer({
-                            command: this.converterCommand,
-                            encoderArgs: options.encoderArgs,
-                            inputArgs: options.inputArgs,
-                            format: options.format,
-                            frameDuration: options.frameDuration
-                        })).once("error", (e) => this.stop(e)));
-                    } else if(typeof source === "string") {
-                        this.streams.push(source = new FFmpegOggTransformer({
-                            command: this.converterCommand,
-                            input: source,
-                            encoderArgs: options.encoderArgs,
-                            inputArgs: options.inputArgs,
-                            format: options.format,
-                            frameDuration: options.frameDuration
-                        }).once("error", (e) => this.stop(e)));
+                        if (typeof source === "string") {
+                            this.streams.push(source = new OggOpusPassthroughTransformer({
+                                command: this.converterCommand,
+                                input: source,
+                                encoderArgs: options.encoderArgs,
+                                inputArgs: options.inputArgs,
+                                format: options.format,
+                                frameDuration: options.frameDuration
+                            }).once("error", (e) => this.stop(e)));
+                        } else {
+                            this.streams.push(source = source.pipe(new OggOpusPassthroughTransformer({
+                                command: this.converterCommand,
+                                encoderArgs: options.encoderArgs,
+                                inputArgs: options.inputArgs,
+                                format: options.format,
+                                frameDuration: options.frameDuration
+                            })).once("error", (e) => this.stop(e)));
+                        }
                     } else {
-                        this.streams.push(source = source.pipe(new FFmpegOggTransformer({
-                            command: this.converterCommand,
-                            encoderArgs: options.encoderArgs,
-                            inputArgs: options.inputArgs,
-                            format: options.format,
-                            frameDuration: options.frameDuration
-                        })).once("error", (e) => this.stop(e)));
+                        if(typeof source === "string") {
+                            this.streams.push(source = new FFmpegOggTransformer({
+                                command: this.converterCommand,
+                                input: source,
+                                encoderArgs: options.encoderArgs,
+                                inputArgs: options.inputArgs,
+                                format: options.format,
+                                frameDuration: options.frameDuration
+                            }).once("error", (e) => this.stop(e)));
+                        } else {
+                            this.streams.push(source = source.pipe(new FFmpegOggTransformer({
+                                command: this.converterCommand,
+                                encoderArgs: options.encoderArgs,
+                                inputArgs: options.inputArgs,
+                                format: options.format,
+                                frameDuration: options.frameDuration
+                            })).once("error", (e) => this.stop(e)));
+                        }
                     }
                     this.streams.push(source.pipe(new OggOpusTransformer()).once("error", (e) => this.stop(e)));
                 } else {

--- a/lib/voice/Piper.js
+++ b/lib/voice/Piper.js
@@ -166,7 +166,7 @@ class Piper extends EventEmitter {
             } else {
                 if(this.libopus) {
                     if(options.opusPassthrough) {
-                        if (typeof source === "string") {
+                        if(typeof source === "string") {
                             this.streams.push(source = new OggOpusPassthroughTransformer({
                                 command: this.converterCommand,
                                 input: source,

--- a/lib/voice/streams/FFmpegOggTransformer.js
+++ b/lib/voice/streams/FFmpegOggTransformer.js
@@ -10,7 +10,6 @@ module.exports = function(options = {}) {
         options.frameDuration = 60;
     }
     let inputArgs = [
-        "-i", options.input || "-",
         "-analyzeduration", "0",
         "-loglevel", "24"
     ].concat(options.inputArgs || []);
@@ -22,6 +21,7 @@ module.exports = function(options = {}) {
         );
     }
     inputArgs = inputArgs.concat(
+        "-i", options.input || "-",
         "-vn"
     );
     const outputArgs = [

--- a/lib/voice/streams/OggOpusPassthroughTransformer.js
+++ b/lib/voice/streams/OggOpusPassthroughTransformer.js
@@ -10,7 +10,6 @@ module.exports = function(options = {}) {
         options.frameDuration = 60;
     }
     let inputArgs = [
-        "-i", options.input || "-",
         "-loglevel", "24"
     ].concat(options.inputArgs || []);
     if(options.format === "pcm") {
@@ -21,6 +20,7 @@ module.exports = function(options = {}) {
         );
     }
     inputArgs = inputArgs.concat(
+        "-i", options.input || "-",
         "-vn"
     );
     const outputArgs = [


### PR DESCRIPTION
Reverts https://github.com/Brainicism/eris/pull/14

Originally did this because of a bug where some songs (e.g ST8O-AeY3Uo). For some reason, this only happens when passing the input as a stream. Passing in the file name works as expected. 

Having the seek as a pre-encode step speeds up the encoding time significantly, to near instant (vs 3-5s)